### PR TITLE
Add a zcam-rs and float32-data demos to work with rs and ROS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ dashboard. Three subscriber frontends are provided: a Python script using
 [Matplotlib](https://matplotlib.org/), a browser client and a
 [Freeboard](https://freeboard.github.io) configuation.
 
-**computer-vision/zcam/zcam-{python,rust,rest}**: consists of two Zenoh nodes: a
+**computer-vision/zcam/zcam-{python,rust,rest,rs-python}**: consists of two Zenoh nodes: a
 publisher capturing a camera video stream and a subscriber displaying said video
 stream. Both of the Python and Rust implementations use
 [OpenCV](https://opencv.org/) to encode and decode data.
@@ -96,6 +96,10 @@ obstacles and environment boundaries (e.g. walls of a room).
 [Twist](https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html)
 teleoperation messages by reading keyboard input (i.e. arrow keys). Both of the
 Rust and Python implementations are terminal applications.
+
+**ROS2/zenoh-python-float32-data**: Zenoh nodes that publish
+[Float32](https://docs.ros.org/en/noetic/api/std_msgs/html/msg/Float32.html)
+Float32 message might be used to publish real-time sensor data such as temperature readings, velocity, or any other numerical value.
 
 **zenoh-home/{light,soil,temp-humi}-sensor**: Zenoh nodes running Zenoh
 [Pico](https://github.com/eclipse-zenoh/zenoh-pico) on an

--- a/ROS2/zenoh-python-float32-data/README.md
+++ b/ROS2/zenoh-python-float32-data/README.md
@@ -1,0 +1,31 @@
+# A zenoh Python Float32 data for ROS2
+
+## **Requirements**
+
+* Python 3.6 minimum
+* A [zenoh router](http://zenoh.io/docs/getting-started/quick-test/)
+* The [zenoh/DDS bridge](https://github.com/eclipse-zenoh/zenoh-plugin-dds#trying-it-out)
+* [zenoh-python](https://github.com/eclipse-zenoh/zenoh-python): install it with `pip install eclipse-zenoh`.
+* [pycdr2](https://pypi.org/project/pycdr2/): install it with `pip install pycdr2`.
+
+-----
+
+## **Usage**
+
+1. Start the zenoh/DDS bridge:
+
+    ```bash
+    zenoh-bridge-dds
+    ```
+
+2. Start Ros2Float32
+
+    ```bash
+    python ros2-float32-data.py
+    ```
+
+3. Start Rviz2 and Setting Plotter2D
+
+    ```bash
+    python ros2-float32-data.py
+    ```

--- a/ROS2/zenoh-python-float32-data/ros2-float32-data.py
+++ b/ROS2/zenoh-python-float32-data/ros2-float32-data.py
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2024 ZettaScale Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   The Zenoh Team, <zenoh@zettascale.tech>
+#
+
+import argparse
+import zenoh
+import random
+import time
+import json
+
+from dataclasses import dataclass
+from pycdr2 import IdlStruct
+from pycdr2.types import int32, uint32, float32
+
+
+@dataclass
+class Time(IdlStruct, typename="Time"):
+    sec: int32
+    nanosec: uint32
+
+@dataclass
+class Float32(IdlStruct, typename="std_msgs/msg/Float32"):
+    data: float32
+
+
+def main():
+    # --- Command line argument parsing ---
+    parser = argparse.ArgumentParser(
+        prog='random_float32_publisher',
+        description='zenoh random Float32 publisher example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--connect', '-e', dest='connect',
+                        metavar='ENDPOINT',
+                        action='append',
+                        type=str,
+                        help='zenoh endpoints to connect to.')
+    parser.add_argument('--listen', '-l', dest='listen',
+                        metavar='ENDPOINT',
+                        action='append',
+                        type=str,
+                        help='zenoh endpoints to listen on.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+    parser.add_argument('--topic', '-t', dest='topic',
+                        default='random_float32',
+                        type=str,
+                        help='The topic to publish Float32 data.')
+    parser.add_argument('--float32_data', '-f', dest='float32_data',
+                        default='10.0',
+                        type=float,
+                        help='The float32_data of publishing.')
+
+    args = parser.parse_args()
+    conf = zenoh.Config.from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5(zenoh.config.MODE_KEY, json.dumps(args.mode))
+    if args.connect is not None:
+        conf.insert_json5(zenoh.config.CONNECT_KEY, json.dumps(args.connect))
+    if args.listen is not None:
+        conf.insert_json5(zenoh.config.LISTEN_KEY, json.dumps(args.listen))
+    topic = args.topic
+    float32_data = args.float32_data
+
+    # zenoh-net session initialization
+    print("Opening session...")
+    session = zenoh.open(conf)
+
+    print(f"Publishing random Float32 data on topic '{topic}' at {float32_data}.")
+
+    def pub_float32(data):
+        print("Pub float32: {}".format(data))
+        t = Float32(data=float(data))
+        session.put(topic, t.serialize())
+
+    try:
+        interval = 1.0 / float32_data
+        while True:
+            random_value = random.uniform(-10, 10.0)  # Generate random float between -100.0 and 100.0
+            pub_float32(random_value)
+            print(f"Published: {random_value} to topic '{topic}'")
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print("Shutting down...")
+    finally:
+        session.close()
+
+if __name__ == "__main__":
+    main()

--- a/ROS2/zenoh-rest-teleop/README.md
+++ b/ROS2/zenoh-rest-teleop/README.md
@@ -37,9 +37,28 @@ via the zenoh REST API, bridged to ROS2.
      * Keep pressing the arrow buttons (or arrows on your keyboard) to publish Twist messages (a STOP Twist with 0 speed is published when released).
      * All the messages published on "rosout" via ROS2 will be displayed in the bottom box.
 
+### ros2-tb3-teleop.html
 
-⚠️ Note: this demo depends on the Ros2 Middleware implementation being set to CycloneDDS  
-Installation instructions for CycloneDDS below:  
-https://docs.ros.org/en/humble/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.html  
-Once installed the middleware env var must be set : 
+A simple teleop web page allowing to publish Twists and to subscribe to Logs
+via the zenoh REST API, bridged to ROS2 for Turtlebot3 on Gazebo.
+
+1. Start the Turtlebot3 launch file:
+Please clone the turtlebot3_simulations package beforehand.
+
+     ```bash
+     RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ros2 launch turtlebot3_gazebo turtlebot3_wolrd.launch.py
+     ```
+
+2. Start the zenoh/DDS bridge, activating its REST API:
+
+     ```bash
+     zenoh-bridge-ros2dds --rest-http-port 8000
+     ```
+
+3. Open the `ros2-tb3-teleop.html` file in a Web browser
+
+⚠️ Note: this demo depends on the Ros2 Middleware implementation being set to CycloneDDS
+Installation instructions for CycloneDDS below:
+https://docs.ros.org/en/humble/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.html
+Once installed the middleware env var must be set :
 `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`

--- a/ROS2/zenoh-rest-teleop/ros2-tb3-teleop.html
+++ b/ROS2/zenoh-rest-teleop/ros2-tb3-teleop.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" />
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body class="w3-container">
+    <div class="w3-container w3-bar w3-card-4 w3-blue w3-margin-bottom">
+        <h3 class="w3-bar-item">Zenoh ROS2 teleop for Turtlebot3</h3>
+    </div>
+
+    <div class="w3-row">
+        <div class="w3-col s2 m2 l2">
+            <label for="rest_api">Zenoh REST API:</label>
+        </div>
+        <div class="w3-col s10 m10 l10">
+            <input id="rest_api" class="w3-input w3-border w3-padding-small" type="text" required
+                value="http://localhost:8000/">
+        </div>
+    </div>
+    <div class="w3-row">
+        <div class="w3-col s2 m2 l2">
+            <label for="rest_api">Namespace : </label>
+        </div>
+        <div class="w3-col s2 m2 l2">
+            <input id="namespace_input" class="w3-input w3-border w3-padding-small w3-margin-right" type="text"
+                value="">
+        </div>
+    </div>
+
+    <br />
+
+    <div class="w3-card-4 w3-margin-bottom">
+        <header class="w3-bar w3-blue" onclick="document.getElementById('Drive').classList.toggle('w3-hide');">
+            <h5 id="drive_label" class="w3-bar-item" style="margin: 0;">Drive</h5>
+            <h5 class="w3-bar-item w3-right" style="margin: 0;"><i class='fa fa-gamepad'></i></h5>
+        </header>
+        <div id="Drive" class="w3-container w3-padding">
+            <div class="w3-auto" style="display: grid; width:15em; height:9em; ">
+                <button onmousedown="loopPubTwist(1.0, 0.0);" onmouseup="stopLoopPubTwist();"
+                    ontouchstart="loopPubTwist(1.0, 0.0);" ontouchend="stopLoopPubTwist();"
+                    style='font-size:2em; grid-column: 2; grid-row: 1;'>
+                    <i class='fas fa-caret-up'></i>
+                </button>
+                <button onmousedown="loopPubTwist(0.0, 1.0);" onmouseup="stopLoopPubTwist();"
+                    ontouchstart="loopPubTwist(0.0, 1.0);" ontouchend="stopLoopPubTwist();"
+                    style='font-size:2em; grid-column: 1; grid-row: 2;'>
+                    <i class='fas fa-caret-left'></i>
+                </button>
+                <button onmousedown="loopPubTwist(-1.0, 0.0);" onmouseup="stopLoopPubTwist();"
+                    ontouchstart="loopPubTwist(-1.0, 0.0);" ontouchend="stopLoopPubTwist();"
+                    style='font-size:2em; grid-column: 2; grid-row: 2;'>
+                    <i class='fas fa-caret-down'></i>
+                </button>
+                <button onmousedown="loopPubTwist(0.0, -1.0);" onmouseup="stopLoopPubTwist();"
+                    ontouchstart="loopPubTwist(0.0, -1.0);" ontouchend="stopLoopPubTwist();"
+                    style='font-size:2em; grid-column: 3; grid-row: 2;'>
+                    <i class='fas fa-caret-right'></i>
+                </button>
+                <button onmousedown="loopPubTwist(0.0, 0.0);" onmouseup="stopLoopPubTwist();"
+                    ontouchstart="loopPubTwist(0.0, 0.0);" ontouchend="stopLoopPubTwist();"
+                    style='font-size:2em; grid-column: 1 / 4; grid-row: 3;'>
+                    STOP
+                </button>
+                <button onmousedown="rotate(Math.PI);" ontouchstart="rotate();"
+                    style='font-size:2em; grid-column: 5; grid-row: 2;'>
+                    <i class='fas fa-rotate-left'></i>
+                </button>
+                <button onmousedown="rotate(0);" ontouchstart="rotate();"
+                    style='font-size:2em; grid-column: 5; grid-row: 3;'>
+                    <i class='fas fa-rotate-right'></i>
+                </button>
+            </div>
+            <br />
+        </div>
+    </div>
+
+    <div class="w3-card-4 w3-margin-bottom">
+        <header class="w3-bar w3-blue" onclick="document.getElementById('Logs').classList.toggle('w3-hide');">
+            <h5 id="logs_label" class="w3-bar-item" style="margin: 0;">Logs</h5>
+            <h5 class="w3-bar-item w3-right" style="margin: 0;"><i class='fa fa-envelope'></i></h5>
+        </header>
+        <div id="Logs" class="w3-container w3-padding">
+            <div style="overflow:auto; height:200px; border:1px solid black;" id="rosout_logs"></div>
+        </div>
+    </div>
+
+    <div class="w3-card-4 w3-margin-bottom">
+        <header class="w3-bar w3-blue" onclick="document.getElementById('Config').classList.toggle('w3-hide');">
+            <h5 class="w3-bar-item" style="margin: 0;">Config</h5>
+            <h5 class="w3-bar-item w3-right" style="margin: 0;"><i class='fa fa-gear'></i></h5>
+        </header>
+        <form id="Config" class="w3-container w3-hide">
+            <label for="linear_scale">Linear scale:</label>
+            <input id="linear_scale" class="w3-input w3-border w3-padding-small" type="number" required
+                value="0.2"><br />
+            <label for="angular_scale">Angular scale:</label>
+            <input id="angular_scale" class="w3-input w3-border w3-padding-small" type="number" required
+                value="0.2"><br />
+            <input type="submit" class="w3-btn w3-blue" value="Reset subscriptions"
+                onclick="resetAllSubscriptions(); return false"><br />
+            <br />
+        </form>
+    </div>
+
+
+    <script src="https://cdn.jsdelivr.net/npm/bytebuffer@5.0.1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jscdr@0.0.1"></script>
+    <script>
+        // ROS2 topic names
+        const TOPIC_DRIVE = "cmd_vel";
+        const TOPIC_LOGS = "rosout";
+        const ACTION_ROTATE = "rotate_absolute/_action/send_goal";
+
+        // Get "rest" and "namespace" from URL params, and set "rest_api" and "namespace_input" elements accordingly
+        const urlParams = new URLSearchParams(window.location.search);
+        const restParam = urlParams.get('rest');
+        if (restParam != null && restParam.length > 0) {
+            console.log("Set REST API from URL params: " + restParam);
+            document.getElementById("rest_api").value = restParam;
+        }
+        const namespaceParam = urlParams.get('namespace');
+        if (namespaceParam != null && namespaceParam.length > 0) {
+            console.log("Set custom namespace from URL params: " + namespaceParam);
+            document.getElementById("namespace_input").value = namespaceParam;
+        }
+
+        // Add listener for input changes REST API and Namespace inputs
+        document.getElementById("rest_api").addEventListener('change', (event) => {
+            reloadPage(event.target.value, document.getElementById("namespace_input").value);
+        });
+        document.getElementById("namespace_input").addEventListener('change', (event) => {
+            reloadPage(document.getElementById("rest_api").value, event.target.value);
+        });
+        function reloadPage(rest, s) {
+            window.location.search = 'rest=' + rest + "&namespace=" + s;
+        }
+
+        // The REST API URL
+        var rest_api = document.getElementById("rest_api").value;
+
+        // The namespace (used as a prefix for all Zenoh keys to publish and subscribe if not containing '*')
+        var namespace = document.getElementById("namespace_input").value;
+        if (namespace.length > 0 && !namespace.endsWith("/")) { namespace += "/" }
+
+        /////////////////////////
+        //  Twist publication  //
+        /////////////////////////
+
+        // Update Drive label
+        let elem = document.getElementById("drive_label");
+        elem.innerHTML = "Drive ( " + namespace + TOPIC_DRIVE + " )"
+
+        // HTTP client to call the REST API
+        const Http = new XMLHttpRequest();
+
+        // Function to publish a Twist to cmd_vel topic
+        function pubTwist(linear, angular) {
+            // Get scales from HTML
+            var linear_scale = document.getElementById("linear_scale").value
+            var angular_scale = document.getElementById("angular_scale").value
+
+            // Create a Twist message
+            var twist = new Twist(
+                new Vector3(linear * linear_scale, 0.0, 0.0),
+                new Vector3(0.0, 0.0, angular * angular_scale));
+            console.log(twist);
+            // Since it's going to DDS, encode it using a jscdr.CDRWriter
+            var writer = new jscdr.CDRWriter();
+            twist.encode(writer);
+
+            // The key expression for publication
+            var key_expr = namespace + TOPIC_DRIVE;
+            console.log("Send cmd_vel to " + rest_api + key_expr);
+
+            // PUT it to zenoh via its REST API
+            Http.open('PUT', rest_api + key_expr, true);
+            Http.setRequestHeader('Content-Type', 'application/octet-stream');
+            Http.send(writer.buf.buffer);
+        }
+
+        var pubTwistTimer;
+        // Function publishing Twists in loop at 200ms interval
+        function loopPubTwist(linear, angular) {
+            if (pubTwistTimer) return;
+            console.log("start publishing Twists (" + linear + "," + angular + ")");
+            clearInterval(pubTwistTimer);
+            pubTwistTimer = setInterval(pubTwist, 200, linear, angular);
+        }
+        // Function stopping the publication loop of Twists
+        function stopLoopPubTwist() {
+            console.log("stop publishing Twists");
+            clearInterval(pubTwistTimer);
+            pubTwistTimer = null;
+        }
+
+
+        // callback on keyboard's down key event
+        function onkeydown(e) {
+            e = e || window.event;
+            console.log("KeyPressed: " + e);
+            if (e.keyCode == '38') {
+                // up arrow
+                loopPubTwist(1.0, 0.0);
+            }
+            else if (e.keyCode == '40') {
+                // down arrow
+                loopPubTwist(-1.0, 0.0);
+            }
+            else if (e.keyCode == '37') {
+                console.log("LEFT => setInterval")
+                // left arrow
+                loopPubTwist(0.0, 1.0);
+            }
+            else if (e.keyCode == '39') {
+                console.log("RIGHT => setInterval")
+                // right arrow
+                loopPubTwist(0.0, -1.0);
+            }
+            else if (e.keyCode == '32') {
+                // spacebar
+                stopLoopPubTwist();
+            }
+        }
+        // register callback on key down
+        document.onkeydown = onkeydown;
+
+        // callback on keyboard's up key event
+        function onkeyup(e) {
+            // if key pressed was an arrow, send a Twist(0,0) to stop the robot
+            if (e.keyCode == '37' || e.keyCode == '38' || e.keyCode == '39' || e.keyCode == '40') {
+                stopLoopPubTwist();
+            }
+        }
+        // register callback on key up
+        document.onkeyup = onkeyup;
+
+        /////////////////////////
+        //    Rotate action    //
+        /////////////////////////
+        function rotate(theta) {
+            // Action type: https://github.com/iRobotEducation/irobot_create_msgs/blob/rolling/action/RotateAngle.action
+            // The request body is CDR-encoded with:
+            //  - random goal UUID
+            //  - theta: float32 in radians
+            //  - max_rotation_speed: float32
+            var writer = new jscdr.CDRWriter();
+            for (let i = 0; i < 16; i++) {
+                writer.writeByte(Math.floor(Math.random() * 256));
+            }
+            writer.writeFloat32(theta);
+
+            var key_expr = namespace + ACTION_ROTATE;
+            console.log("Send rotate request to " + rest_api + key_expr);
+
+            // send the Request with a POST HTTP method
+            Http.open('POST', rest_api + key_expr, true);
+            Http.setRequestHeader('Content-Type', 'application/octet-stream');
+            Http.send(writer.buf.buffer);
+        }
+
+        //////////////////////////////////
+        //    Logs subscription (ROS2)  //
+        //////////////////////////////////
+        var ros2_logs_source = null;
+
+        // Test if Server-Source Event is supported
+        if (typeof (EventSource) !== "undefined") {
+            // the key expression to subscribe
+            var key_expr = /*sub_namespace +*/ TOPIC_LOGS;  // (Note: turtlesim don't prepend "rosout" with the namespace)
+
+            // update Lidar label
+            let elem = document.getElementById("logs_label");
+            elem.innerHTML = "Logs ( " + key_expr + " )";
+
+            // Create EventSource for subscription to key_expr
+            console.log("Subscribe to EventSource: " + rest_api + key_expr);
+            ros2_logs_source = new EventSource(rest_api + key_expr);
+            ros2_logs_source.addEventListener("PUT", function (e) {
+                console.log("Received sample: " + e.data);
+                // The zenoh REST API sends JSON objects
+                // that includes "key", "value", "encoding" and "time" (same than a result to GET)
+                let sample = JSON.parse(e.data)
+                // The payload buffer is in "value" field, encoded as base64.
+                // Since it's comming from DDS, we decode it using a jscdr.CDRReader.
+                let reader = new jscdr.CDRReader(dcodeIO.ByteBuffer.fromBase64(sample.value));
+                // Decode the buffer as a Log message
+                let log = Log.decode(reader);
+                // Add it to "rosout_logs" HTML element
+                let elem = document.getElementById("rosout_logs");
+                elem.innerHTML += "ROS2: [" + log.time.sec + "." + log.time.nsec + "] [" + log.name + "]: " + log.msg + "<br>";
+                // Auto-scroll to the bottom
+                elem.scrollTop = elem.scrollHeight;
+            }, false);
+
+        } else {
+            document.getElementById("rosout_logs").innerHTML = "Sorry, your browser does not support server-sent events...";
+        }
+
+        /////////////////////////////////////////////////////////////
+        // ROS2 Types declaration with CDR encode/decode functions //
+        /////////////////////////////////////////////////////////////
+
+        // ROS2 Time type
+        class Time {
+            constructor(sec, nsec) {
+                this.sec = sec;
+                this.nsec = nsec;
+            }
+
+            static decode(cdrReader) {
+                let sec = cdrReader.readInt32();
+                let nsec = cdrReader.readUint32();
+                return new Time(sec, nsec);
+            }
+        }
+
+        // ROS2 Log type (received in 'rosout' topic)
+        class Log {
+            constructor(time, level, name, msg, file, fn, line) {
+                this.time = time;
+                this.level = level;
+                this.name = name;
+                this.msg = msg;
+                this.file = file;
+                this.fn = fn;
+                this.line = line;
+            }
+
+            static decode(cdrReader) {
+                let time = Time.decode(cdrReader);
+                let level = cdrReader.readByte();
+                let name = cdrReader.readString();
+                let msg = cdrReader.readString();
+                let file = cdrReader.readString();
+                let fn = cdrReader.readString();
+                let line = cdrReader.readUint32();
+                return new Log(time, level, name, msg, file, fn, line);
+            }
+        }
+
+        // ROS2 Vector3 type
+        class Vector3 {
+            constructor(x, y, z) {
+                this.x = x;
+                this.y = y;
+                this.z = z;
+            }
+
+            encode(cdrWriter) {
+                cdrWriter.writeFloat64(this.x);
+                cdrWriter.writeFloat64(this.y);
+                cdrWriter.writeFloat64(this.z);
+            }
+
+            static decode(cdrReader) {
+                let x = cdrReader.readFloat64();
+                let y = cdrReader.readFloat64();
+                let z = cdrReader.readFloat64();
+                return new Vector3(x, y, z);
+            }
+        }
+
+        // ROS2 Quaternion type
+        class Quaternion {
+            constructor(x, y, z, w) {
+                this.x = x;
+                this.y = y;
+                this.z = z;
+                this.w = w;
+            }
+
+            static decode(cdrReader) {
+                let x = cdrReader.readFloat64();
+                let y = cdrReader.readFloat64();
+                let z = cdrReader.readFloat64();
+                let w = cdrReader.readFloat64();
+                return new Quaternion(x, y, z, w);
+            }
+        }
+
+        // ROS2 Twist type (published in 'cmd_vel' topic)
+        class Twist {
+            constructor(linear, angular) {
+                this.linear = linear;
+                this.angular = angular;
+            }
+
+            encode(cdrWriter) {
+                this.linear.encode(cdrWriter);
+                this.angular.encode(cdrWriter);
+            }
+        }
+
+        // ROS2 Header type
+        class Header {
+            constructor(time, frame_id) {
+                this.time = time;
+                this.frame_id = frame_id;
+            }
+
+            static decode(cdrReader) {
+                let time = Time.decode(cdrReader);
+                let frame_id = cdrReader.readString();
+            }
+        }
+
+
+    </script>
+
+    <script type="text/javascript">
+    </script>
+
+</body>
+
+</html>

--- a/computer-vision/zcam/zcam-rs-python/README.md
+++ b/computer-vision/zcam/zcam-rs-python/README.md
@@ -1,0 +1,19 @@
+
+# zcam-rs-python -- Streaming video with zenoh-realsense-python
+
+This is a simple application that shows how to stream Intel RealSense Stream with [zenoh](http://zenoh.io)
+
+## Dependencies
+
+```bash
+pip3 install eclipse-zenoh opencv-python numpy imutils
+sudo apt-get install librealsense2-dkms librealsense2-utils librealsense2-dev librealsense2-dbg
+pip install pyrealsense2
+```
+
+## Running zcam-python
+
+```bash
+python3 zcapture_rs.py
+python3 zdisplay_rs.py
+```

--- a/computer-vision/zcam/zcam-rs-python/zcapture_rs.py
+++ b/computer-vision/zcam/zcam-rs-python/zcapture_rs.py
@@ -1,0 +1,68 @@
+import zenoh
+import cv2
+import numpy as np
+import pyrealsense2 as rs
+import argparse
+import json
+import time
+
+# Argument settings
+parser = argparse.ArgumentParser(
+    prog='zrs_capture',
+    description='Zenoh RealSense RGB and Depth capture example')
+parser.add_argument('-m', '--mode', type=str, choices=['peer', 'client'],
+                    help='The zenoh session mode.')
+parser.add_argument('-e', '--connect', type=str, metavar='ENDPOINT', action='append',
+                    help='Zenoh endpoints to connect to.')
+parser.add_argument('-l', '--listen', type=str, metavar='ENDPOINT', action='append',
+                    help='Zenoh endpoints to listen on.')
+parser.add_argument('-k', '--key', type=str, default='demo/zcam',
+                    help='Key expression')
+parser.add_argument('-c', '--config', type=str, metavar='FILE',
+                    help='A Zenoh configuration file.')
+args = parser.parse_args()
+
+# Zenoh configuration
+conf = zenoh.Config.from_file(args.config) if args.config is not None else zenoh.Config()
+z = zenoh.open(conf)
+
+# RealSense pipeline configuration
+pipeline = rs.pipeline()
+config = rs.config()
+config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)  # RGB
+config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)   # Depth
+
+pipeline.start(config)
+
+print("[INFO] Open RealSense camera...")
+
+# Publish frames to Zenoh
+def publish_frames():
+    while True:
+        # Wait for frames
+        frames = pipeline.wait_for_frames()
+        color_frame = frames.get_color_frame()
+        depth_frame = frames.get_depth_frame()
+
+        if not color_frame or not depth_frame:
+            continue
+
+        # Get RGB image
+        rgb_image = np.asanyarray(color_frame.get_data())
+        _, jpeg_rgb = cv2.imencode('.jpg', rgb_image)
+        z.put(args.key + "/rgb", jpeg_rgb.tobytes())
+
+        # Get Depth image
+        depth_image = np.asanyarray(depth_frame.get_data())
+
+        # Convert Depth data to color image (apply color map)
+        depth_colormap = cv2.applyColorMap(cv2.convertScaleAbs(depth_image, alpha=0.03), cv2.COLORMAP_JET)
+
+        # Encode Depth image in JPEG format
+        _, jpeg_depth = cv2.imencode('.jpg', depth_colormap)
+        z.put(args.key + "/depth", jpeg_depth.tobytes())
+
+        time.sleep(0.05)
+
+# Send frames
+publish_frames()

--- a/computer-vision/zcam/zcam-rs-python/zdisplay_rs.py
+++ b/computer-vision/zcam/zcam-rs-python/zdisplay_rs.py
@@ -1,0 +1,85 @@
+import argparse
+import time
+import cv2
+import zenoh
+import numpy as np
+import json
+
+# Argument parser
+parser = argparse.ArgumentParser(
+    prog='zdisplay',
+    description='zenoh video display example')
+parser.add_argument('-m', '--mode', type=str, choices=['peer', 'client'],
+                    help='The zenoh session mode.')
+parser.add_argument('-e', '--connect', type=str, metavar='ENDPOINT', action='append',
+                    help='zenoh endpoints to connect to.')
+parser.add_argument('-l', '--listen', type=str, metavar='ENDPOINT', action='append',
+                    help='zenoh endpoints to listen on.')
+parser.add_argument('-d', '--delay', type=float, default=0.05,
+                    help='delay between each frame in seconds')
+parser.add_argument('-k', '--key', type=str, default='demo/zcam',
+                    help='key expression')
+parser.add_argument('-c', '--config', type=str, metavar='FILE',
+                    help='A zenoh configuration file.')
+
+args = parser.parse_args()
+
+# Zenoh session setup
+conf = zenoh.Config.from_file(args.config) if args.config is not None else zenoh.Config()
+
+# Setting Zenoh mode (peer or client)
+if args.mode is not None:
+    conf.insert_json5("mode", json.dumps(args.mode))
+
+# Connect to the provided endpoints, or use a default if not provided
+if args.connect is not None:
+    conf.insert_json5("connect", json.dumps(args.connect))
+else:
+    # Default to localhost if no connect endpoint is specified
+    print("[INFO] No connect endpoint specified, using default endpoint (tcp://127.0.0.1:7447).")
+
+# Listen to the provided endpoints if any
+if args.listen is not None:
+    conf.insert_json5("listen", json.dumps(args.listen))
+
+# Dictionary to store camera images
+cams = {}
+
+def frames_listener(sample):
+    """Callback function for Zenoh subscriber"""
+    # Convert received image data (ZBytes type) to numpy array
+    npImage = np.frombuffer(bytes(sample.payload), dtype=np.uint8)
+    matImage = cv2.imdecode(npImage, 1)
+
+    # Update the latest camera image (separate management for RGB and Depth)
+    cams[sample.key_expr] = matImage
+
+# Open Zenoh session
+print('[INFO] Open zenoh session...')
+z = zenoh.open(conf)
+
+# Declare subscribers for RGB and Depth
+sub_rgb = z.declare_subscriber(args.key + "/rgb", frames_listener)
+sub_depth = z.declare_subscriber(args.key + "/depth", frames_listener)
+
+while True:
+    # Display all camera images in separate windows
+    for cam_key, cam_img in cams.items():
+        # Convert cam_key to string
+        cam_key_str = str(cam_key)
+
+        if 'rgb' in cam_key_str:
+            cv2.imshow(f"RGB Camera: {cam_key_str}", cam_img)  # Display RGB camera
+        elif 'depth' in cam_key_str:
+            cv2.imshow(f"Depth Camera: {cam_key_str}", cam_img)  # Display Depth camera
+
+    # Exit on ESC key
+    key = cv2.waitKey(1) & 0xFF
+    if key == 27:  # Exit on ESC key
+        break
+
+    # Add delay before receiving the next frame
+    time.sleep(args.delay)
+
+# Close the windows
+cv2.destroyAllWindows()


### PR DESCRIPTION
Added demo code for zcam-rs and zenoh python code.

# Items and details
- zenoh-python-float32-data
High demand for float32 format demo for sending sensor data.

- zenoh-rest-teleop
By introducing ros2-tb3-teleop.html for Turtlebot3 operation, it can be used quickly.

- zcam-rs-python
Addition of Intel Realsense 3D camera zcam demo expands versatility.