### PR TITLE
Fix buffer conversion in frames_listener function

### DIFF
--- a/computer-vision/zcam/zcam-python/zdisplay.py
+++ b/computer-vision/zcam/zcam-python/zdisplay.py
@@ -34,7 +34,7 @@ if args.listen is not None:
 cams = {}
 
 def frames_listener(sample):
-    npImage = np.frombuffer(bytes(sample.value.payload), dtype=np.uint8)
+    npImage = np.frombuffer(bytes(sample.payload), dtype=np.uint8)
     matImage = cv2.imdecode(npImage, 1)
 
     cams[sample.key_expr] = matImage


### PR DESCRIPTION
# Bug

When running as instructed:

```python
AttributeError: 'builtins.Sample' object has no attribute 'value'
callback error
Traceback (most recent call last):
  File "/Users/michaelmentele/Development/trying-shit/zenoh-demos/computer-vision/zcam/zcam-python/zdisplay.py", line 37, in frames_listener
    npImage = np.frombuffer(bytes(sample.value.payload), dtype=np.uint8)
                                  ^^^^^^^^^^^^
AttributeError: 'builtins.Sample' object has no attribute 'value'
^CTraceback (most recent call last):
  File "/Users/michaelmentele/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/threading.py", line 1540, in _shutdown
    _thread_shutdown()
KeyboardInterrupt: 
```

## With the change
Works as expected, though apparently my webcam makes thumbs up emojis that linger when I thumbs up.
<img width="488" height="305" alt="image" src="https://github.com/user-attachments/assets/45098566-f3a3-482d-ae3a-9e220f3b8c3a" />
